### PR TITLE
Allow the script to be run from any folder

### DIFF
--- a/grep_typos.sh
+++ b/grep_typos.sh
@@ -46,10 +46,20 @@ do
 done
 
 
+# Determine the script location
+# https://stackoverflow.com/a/246128
+source="${BASH_SOURCE[0]}"
+while [ -h "$source" ]; do # resolve $source until the file is no longer a symlink
+  directory="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+  [[ $source != /* ]] && source="$directory/$source" # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+script_directory="$( cd -P "$( dirname "$source" )" && pwd )"
+
 if [ "$match_substrings" == true ];then
-  data_file="data/typos.txt"
+  data_file="${script_directory}/data/typos.txt"
 else
-  data_file="data/common_misspellings.txt"
+  data_file="${script_directory}/data/common_misspellings.txt"
 fi
 
 


### PR DESCRIPTION
Previously the database file was specified relative to the current folder, which required the script to be run from its own folder.

I'll admit to just copy/pasting this code from Stack Overflow. It does work for me, and seems to be highly regarded over there.